### PR TITLE
MAKE_SHARED_FROM_STATIC; MXE_INTRINSIC_SH; freetype and dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -249,11 +249,12 @@ MXE_DISABLE_DOCS = \
 
 MXE_DISABLE_CRUFT = $(MXE_DISABLE_PROGRAMS) $(MXE_DISABLE_DOCS)
 
+# NOTE the branching on BUILD_CROSS can be removed when the native toolchain resides within the prefix. Better sooner than later!
 MAKE_SHARED_FROM_STATIC = \
 	'$(TOP_DIR)/tools/make-shared-from-static' \
 	$(if $(findstring mingw,$(TARGET)),--windowsdll) \
-	--ar '$(TARGET)-ar' \
-	--ld '$(TARGET)-gcc' \
+	--ar $(if $(BUILD_CROSS), '$(TARGET)-ar', ar) \
+	--ld $(if $(BUILD_CROSS), '$(TARGET)-gcc', gcc) \
 	--install '$(INSTALL)' \
 	--libdir '$(PREFIX)/$(TARGET)/lib' \
 	--bindir '$(PREFIX)/$(TARGET)/bin'

--- a/src/bzip2.mk
+++ b/src/bzip2.mk
@@ -31,11 +31,6 @@ endef
 define $(PKG)_BUILD
     $($(PKG)_BUILD_COMMON)
     $(INSTALL) -m644 '$(1)/libbz2.a' '$(PREFIX)/$(TARGET)/lib/'
-endef
 
-define $(PKG)_BUILD_SHARED
-    $($(PKG)_BUILD_COMMON)
-    '$(TARGET)-gcc' '$(1)'/*.o -shared \
-        -o '$(PREFIX)/$(TARGET)/bin/libbz2.dll' -Xlinker \
-        --out-implib -Xlinker '$(PREFIX)/$(TARGET)/lib/libbz2.dll.a'
+    $(if $(BUILD_SHARED), $(MAKE_SHARED_FROM_STATIC) '$(1)/libbz2.a',)
 endef

--- a/src/icu4c.mk
+++ b/src/icu4c.mk
@@ -4,13 +4,13 @@ PKG             := icu4c
 $(PKG)_WEBSITE  := https://github.com/unicode-org/icu
 $(PKG)_DESCR    := ICU4C
 $(PKG)_IGNORE   :=
-$(PKG)_VERSION  := 66.1
-$(PKG)_MAJOR    := $(word 1,$(subst ., ,$($(PKG)_VERSION)))
-$(PKG)_CHECKSUM := 52a3f2209ab95559c1cf0a14f24338001f389615bf00e2585ef3dbc43ecf0a2e
+$(PKG)_VERSION  := 68.2
+$(PKG)_MAJOR    := icu.tar.gz
+$(PKG)_CHECKSUM := 8764da8c85d8479f816cfc894aea227d98f5b40a9be55db5fd903fdd46806f88
 $(PKG)_GH_CONF  := unicode-org/icu/releases/latest,release-,,,-
 $(PKG)_SUBDIR   := icu
-$(PKG)_URL      := $($(PKG)_WEBSITE)/releases/download/release-$(subst .,-,$($(PKG)_VERSION))/icu4c-$(subst .,_,$($(PKG)_VERSION))-src.tgz
-$(PKG)_DEPS     := cc $(BUILD)~$(PKG)
+$(PKG)_URL      := https://github.com/armdevvel/icu4c/releases/download/v68.2/icu68.tar.gz
+$(PKG)_DEPS     := cc $(BUILD)~$(PKG) pe-util
 
 $(PKG)_TARGETS       := $(BUILD) $(MXE_TARGETS)
 $(PKG)_DEPS_$(BUILD) :=
@@ -29,6 +29,7 @@ endef
 
 define $(PKG)_BUILD_COMMON
     rm -fv $(shell echo "$(PREFIX)/$(TARGET)"/{bin,lib}/{lib,libs,}icu'*'.{a,dll,dll.a})
+    $(SED) -i 's/-Wl,-Bsymbolic/ /g' '$(SOURCE_DIR)/source/config/mh-mingw'
     cd '$(BUILD_DIR)' && '$(SOURCE_DIR)/source/configure' \
         $(MXE_CONFIGURE_OPTS) \
         --with-cross-build='$(PREFIX)/$(BUILD)/$(PKG)' \
@@ -37,7 +38,7 @@ define $(PKG)_BUILD_COMMON
         SHELL=$(SHELL) \
         LIBS='-lstdc++' \
         $($(PKG)_CONFIGURE_OPTS)
-
+        
     $(MAKE) -C '$(BUILD_DIR)' -j '$(JOBS)' VERBOSE=1 SO_TARGET_VERSION_SUFFIX=
     $(MAKE) -C '$(BUILD_DIR)' -j 1 install VERBOSE=1 SO_TARGET_VERSION_SUFFIX=
 endef

--- a/src/libffi.mk
+++ b/src/libffi.mk
@@ -3,13 +3,12 @@
 PKG             := libffi
 $(PKG)_WEBSITE  := https://sourceware.org/libffi/
 $(PKG)_IGNORE   :=
-$(PKG)_VERSION  := 3.3
-$(PKG)_CHECKSUM := 72fba7922703ddfa7a028d513ac15a85c8d54c8d67f55fa5a4802885dc652056
+$(PKG)_VERSION  := 3.3.fixed
+$(PKG)_CHECKSUM := ba998513d28c325d0c1ad6e4791bda87d2e7dafbb34ef2cbf3ddbb91ee3dca30
 $(PKG)_GH_CONF  := atgreen/libffi/tags, v
 $(PKG)_SUBDIR   := $(PKG)-$($(PKG)_VERSION)
 $(PKG)_FILE     := $(PKG)-$($(PKG)_VERSION).tar.gz
-$(PKG)_URL      := https://www.mirrorservice.org/sites/sourceware.org/pub/$(PKG)/$($(PKG)_FILE)
-$(PKG)_URL_2    := https://sourceware.org/pub/$(PKG)/$($(PKG)_FILE)
+$(PKG)_URL      := https://github.com/armdevvel/libffi/releases/download/3.3-fix/libffi-3.3.fixed.tar.gz
 $(PKG)_TARGETS  := $(BUILD) $(MXE_TARGETS)
 $(PKG)_DEPS     := cc
 
@@ -19,6 +18,7 @@ define $(PKG)_BUILD
     # build and install the library
     cd '$(BUILD_DIR)' && $(SOURCE_DIR)/configure \
         $(MXE_CONFIGURE_OPTS)
+    $(SED) -i 's/-Wl,--version-script,libffi.map/ /g' '$(BUILD_DIR)/Makefile'
     $(MAKE) -C '$(BUILD_DIR)' -j '$(JOBS)'
     $(MAKE) -C '$(BUILD_DIR)' -j 1 install
 

--- a/src/pcre.mk
+++ b/src/pcre.mk
@@ -9,7 +9,7 @@ $(PKG)_CHECKSUM := 4dae6fdcd2bb0bb6c37b5f97c33c2be954da743985369cddac3546e3218bf
 $(PKG)_SUBDIR   := pcre-$($(PKG)_VERSION)
 $(PKG)_FILE     := pcre-$($(PKG)_VERSION).tar.bz2
 $(PKG)_URL      := https://$(SOURCEFORGE_MIRROR)/project/pcre/pcre/$($(PKG)_VERSION)/$($(PKG)_FILE)
-$(PKG)_DEPS     := cc
+$(PKG)_DEPS     := cc zlib bzip2 readline
 
 define $(PKG)_BUILD_SHARED
     cd '$(1)' && ./configure \
@@ -17,11 +17,18 @@ define $(PKG)_BUILD_SHARED
         --enable-pcre16 \
         --enable-utf \
         --enable-unicode-properties \
-        --enable-cpp \
-        --disable-pcregrep-libz \
-        --disable-pcregrep-libbz2 \
-        --disable-pcretest-libreadline
-    $(MAKE) -C '$(1)' -j '$(JOBS)' install $(MXE_DISABLE_PROGRAMS) dist_html_DATA= dist_doc_DATA=
+        --enable-cpp
+    
+    # NOTE /1/ {a,b}{c,d} is the Bash for combinatorial enumeration, resolves to "ac ad bc bd"
+    # NOTE /2/ There is a suppressed test suite in this package; we may want to reactivate it.
+    $(MAKE) -C '$(1)' \
+        -j '$(JOBS)' \
+        $(MXE_DISABLE_PROGRAMS) \
+        LDFLAGS='`$(MXE_INTRINSIC_SH) aeabi_{,u}{i,l}divmod.S.obj {,u}divmodsi4.S.obj {,u}divmoddi4.c.obj chkstk.S.obj`' \
+        dist_html_DATA= \
+        dist_doc_DATA= \
+        install
+
     rm -f '$(PREFIX)/$(TARGET)'/share/man/man1/pcre*.1
     rm -f '$(PREFIX)/$(TARGET)'/share/man/man3/pcre*.3
     ln -sf '$(PREFIX)/$(TARGET)/bin/pcre-config' '$(PREFIX)/bin/$(TARGET)-pcre-config'

--- a/src/pixman-1-fixes.patch
+++ b/src/pixman-1-fixes.patch
@@ -1,0 +1,37 @@
+diff --git a/test/utils-prng.c b/test/utils-prng.c
+index c27b5be8..3555f3dd 100644
+--- a/test/utils-prng.c
++++ b/test/utils-prng.c
+@@ -27,9 +27,13 @@
+ #include "utils.h"
+ #include "utils-prng.h"
+ 
+-#if defined(HAVE_GCC_VECTOR_EXTENSIONS) && defined(__SSE2__)
++#if defined(HAVE_GCC_VECTOR_EXTENSIONS)
++#if defined(__SSE2__)
+ #include <xmmintrin.h>
+-#endif
++#elif defined(__ARM_NEON)
++#include <arm_neon.h>
++#endif // __ARM_NEON
++#endif // HAVE_GCC_VECTOR_EXTENSIONS
+ 
+ void smallprng_srand_r (smallprng_t *x, uint32_t seed)
+ {
+@@ -200,11 +204,16 @@ randmemset_internal (prng_t                  *prng,
+         else
+         {
+ #ifdef HAVE_GCC_VECTOR_EXTENSIONS
++#ifdef __ARM_NEON
++            // no shuffle in CLang, though VTBL could implement it generically
++            randdata.vb = vrev32q_u8(randdata.vb);
++#else
+             const uint8x16 bswap_shufflemask =
+             {
+                 3, 2, 1, 0, 7, 6, 5, 4, 11, 10, 9, 8, 15, 14, 13, 12
+             };
+             randdata.vb = __builtin_shuffle (randdata.vb, bswap_shufflemask);
++#endif
+             store_rand_128_data (buf, &randdata, aligned);
+             buf += 16;
+ #else

--- a/src/zlib.mk
+++ b/src/zlib.mk
@@ -25,15 +25,6 @@ define $(PKG)_BUILD
         --prefix='$(PREFIX)/$(TARGET)' \
         --static
     $(MAKE) -C '$(1)' -j '$(JOBS)' install
-endef
 
-define $(PKG)_BUILD_SHARED
-    $(MAKE) -C '$(1)' -f win32/Makefile.gcc \
-        SHARED_MODE=1 \
-        STATICLIB= \
-        BINARY_PATH='$(PREFIX)/$(TARGET)/bin' \
-        INCLUDE_PATH='$(PREFIX)/$(TARGET)/include' \
-        LIBRARY_PATH='$(PREFIX)/$(TARGET)/lib' \
-        PREFIX='$(TARGET)-' \
-        -j '$(JOBS)' install
+    $(if $(BUILD_SHARED), $(MAKE_SHARED_FROM_STATIC) '$(1)/libz.a',)
 endef

--- a/src/zlib.mk
+++ b/src/zlib.mk
@@ -21,7 +21,7 @@ define $(PKG)_UPDATE
 endef
 
 define $(PKG)_BUILD
-    cd '$(1)' && CHOST='$(TARGET)' ./configure \
+    cd '$(1)' && CHOST='$(TARGET)' CFLAGS=-fPIC ./configure \
         --prefix='$(PREFIX)/$(TARGET)' \
         --static
     $(MAKE) -C '$(1)' -j '$(JOBS)' install

--- a/tools/make-shared-from-static
+++ b/tools/make-shared-from-static
@@ -23,7 +23,7 @@ libsuffix=
 LIBS=
 
 topdir=$(pwd)
-tmpdir=$topdir/make-shared-from-static.$$
+tmpdir=$topdir/tmp-make-shared-from-static.$$
 
 #trap "cd $topdir; rm -rf $tmpdir" 1 2 15
 


### PR DESCRIPTION
Packages fixed or "dynamized": bzip2, zlib, libpng, pcre, libffi, icu4c, pixman

Documentation debt:
* MAKE_SHARED_FROM_STATIC
* MXE_INTRINSIC_SH (and how to look up builtins)
* libtool and _"I have the capability to make that library automatically"_

Technical debt:
* (short-term) review libtool supply chain requirements.
* (medium-term) review icu4c fixes;
* (medium-term) move host toolchain to prefix so that `$(TARGET)-gcc` were always valid;
* (long-term) review forks, compact minimal fixes as patches, reconnect others to original repos.