### PR TITLE
openssl and immediate dependents

### DIFF
--- a/src/libdvdetect.mk
+++ b/src/libdvdetect.mk
@@ -13,7 +13,8 @@ define $(PKG)_BUILD
     cd '$(BUILD_DIR)' && \
         '$(SOURCE_DIR)'/configure \
         $(MXE_CONFIGURE_OPTS)
-    $(MAKE) -C '$(BUILD_DIR)' -j '$(JOBS)'
+    $(MAKE) -C '$(BUILD_DIR)' -j '$(JOBS)' \
+        LDFLAGS='`$(MXE_INTRINSIC_SH) aeabi_{,u}{i,l}divmod.S.obj {,u}divmodsi4.S.obj {,u}divmoddi4.c.obj chkstk.S.obj` -lws2_32 -ltinyxml'
     $(MAKE) -C '$(BUILD_DIR)/include' -j '$(JOBS)' install
     $(MAKE) -C '$(BUILD_DIR)/lib' -j '$(JOBS)' install
 

--- a/src/libmysqlclient.mk
+++ b/src/libmysqlclient.mk
@@ -49,7 +49,7 @@ define $(PKG)_BUILD
     $(INSTALL) -m644 '$(1)/include/'thr_* '$(1)/include/'my_thr* '$(PREFIX)/$(TARGET)/include'
 
     # build test with mysql_config
-    '$(TARGET)-g++' \
+    '$(TARGET)-gcc' \
         -W -Wall -Werror -ansi -pedantic \
         '$(TEST_FILE)' -o '$(PREFIX)/$(TARGET)/bin/test-$(PKG).exe' \
         `'$(PREFIX)/$(TARGET)/bin/mysql_config' --cflags --libs`

--- a/src/openssl-1-fixes.patch
+++ b/src/openssl-1-fixes.patch
@@ -1,0 +1,189 @@
+diff --git a/Configurations/10-main.conf b/Configurations/10-main.conf
+index b578a3c2..66b1d34e 100644
+--- a/Configurations/10-main.conf
++++ b/Configurations/10-main.conf
+@@ -1513,6 +1513,13 @@ my %targets = (
+         shared_rcflag    => "--target=pe-i386",
+         multilib         => "",
+     },
++    "mingw-arm" => {
++        inherit_from     => ["mingw"],
++        CFLAGS           => "-fPIC",
++        asm_arch         => 'armv4',
++        uplink_arch      => 'armv4',
++        shared_rcflag    => "--target=arm",
++    },
+     "mingw64" => {
+         # As for uplink_arch. Applink makes it possible to use
+         # .dll compiled with one compiler with application compiled with
+diff --git a/crypto/armcap.c b/crypto/armcap.c
+index c021330e..91df58d2 100644
+--- a/crypto/armcap.c
++++ b/crypto/armcap.c
+@@ -34,13 +34,6 @@ uint32_t OPENSSL_rdtsc(void)
+     return 0;
+ }
+ #else
+-static sigset_t all_masked;
+-
+-static sigjmp_buf ill_jmp;
+-static void ill_handler(int sig)
+-{
+-    siglongjmp(ill_jmp, sig);
+-}
+ 
+ /*
+  * Following subroutines could have been inlined, but it's not all
+@@ -143,138 +136,11 @@ static unsigned long getauxval(unsigned long key)
+ void OPENSSL_cpuid_setup(void)
+ {
+     const char *e;
+-    struct sigaction ill_oact, ill_act;
+-    sigset_t oset;
+-    static int trigger = 0;
+-
+-    if (trigger)
+-        return;
+-    trigger = 1;
+-
+-    OPENSSL_armcap_P = 0;
++    OPENSSL_armcap_P = ARMV7_NEON;
+ 
+     if ((e = getenv("OPENSSL_armcap"))) {
+         OPENSSL_armcap_P = (unsigned int)strtoul(e, NULL, 0);
+         return;
+     }
+-
+-# if defined(__APPLE__)
+-#   if !defined(__aarch64__)
+-    /*
+-     * Capability probing by catching SIGILL appears to be problematic
+-     * on iOS. But since Apple universe is "monocultural", it's actually
+-     * possible to simply set pre-defined processor capability mask.
+-     */
+-    if (1) {
+-        OPENSSL_armcap_P = ARMV7_NEON;
+-        return;
+-    }
+-    /*
+-     * One could do same even for __aarch64__ iOS builds. It's not done
+-     * exclusively for reasons of keeping code unified across platforms.
+-     * Unified code works because it never triggers SIGILL on Apple
+-     * devices...
+-     */
+-#   else
+-    {
+-        unsigned int sha512;
+-        size_t len = sizeof(sha512);
+-
+-        if (sysctlbyname("hw.optional.armv8_2_sha512", &sha512, &len, NULL, 0) == 0 && sha512 == 1)
+-            OPENSSL_armcap_P |= ARMV8_SHA512;
+-    }
+-#   endif
+-# endif
+-
+-# ifdef OSSL_IMPLEMENT_GETAUXVAL
+-    if (getauxval(HWCAP) & HWCAP_NEON) {
+-        unsigned long hwcap = getauxval(HWCAP_CE);
+-
+-        OPENSSL_armcap_P |= ARMV7_NEON;
+-
+-        if (hwcap & HWCAP_CE_AES)
+-            OPENSSL_armcap_P |= ARMV8_AES;
+-
+-        if (hwcap & HWCAP_CE_PMULL)
+-            OPENSSL_armcap_P |= ARMV8_PMULL;
+-
+-        if (hwcap & HWCAP_CE_SHA1)
+-            OPENSSL_armcap_P |= ARMV8_SHA1;
+-
+-        if (hwcap & HWCAP_CE_SHA256)
+-            OPENSSL_armcap_P |= ARMV8_SHA256;
+-
+-#  ifdef __aarch64__
+-        if (hwcap & HWCAP_CE_SHA512)
+-            OPENSSL_armcap_P |= ARMV8_SHA512;
+-
+-        if (hwcap & HWCAP_CPUID)
+-            OPENSSL_armcap_P |= ARMV8_CPUID;
+-#  endif
+-    }
+-# endif
+-
+-    sigfillset(&all_masked);
+-    sigdelset(&all_masked, SIGILL);
+-    sigdelset(&all_masked, SIGTRAP);
+-    sigdelset(&all_masked, SIGFPE);
+-    sigdelset(&all_masked, SIGBUS);
+-    sigdelset(&all_masked, SIGSEGV);
+-
+-    memset(&ill_act, 0, sizeof(ill_act));
+-    ill_act.sa_handler = ill_handler;
+-    ill_act.sa_mask = all_masked;
+-
+-    sigprocmask(SIG_SETMASK, &ill_act.sa_mask, &oset);
+-    sigaction(SIGILL, &ill_act, &ill_oact);
+-
+-    /* If we used getauxval, we already have all the values */
+-# ifndef OSSL_IMPLEMENT_GETAUXVAL
+-    if (sigsetjmp(ill_jmp, 1) == 0) {
+-        _armv7_neon_probe();
+-        OPENSSL_armcap_P |= ARMV7_NEON;
+-        if (sigsetjmp(ill_jmp, 1) == 0) {
+-            _armv8_pmull_probe();
+-            OPENSSL_armcap_P |= ARMV8_PMULL | ARMV8_AES;
+-        } else if (sigsetjmp(ill_jmp, 1) == 0) {
+-            _armv8_aes_probe();
+-            OPENSSL_armcap_P |= ARMV8_AES;
+-        }
+-        if (sigsetjmp(ill_jmp, 1) == 0) {
+-            _armv8_sha1_probe();
+-            OPENSSL_armcap_P |= ARMV8_SHA1;
+-        }
+-        if (sigsetjmp(ill_jmp, 1) == 0) {
+-            _armv8_sha256_probe();
+-            OPENSSL_armcap_P |= ARMV8_SHA256;
+-        }
+-#  if defined(__aarch64__) && !defined(__APPLE__)
+-        if (sigsetjmp(ill_jmp, 1) == 0) {
+-            _armv8_sha512_probe();
+-            OPENSSL_armcap_P |= ARMV8_SHA512;
+-        }
+-#  endif
+-    }
+-# endif
+-
+-    /*
+-     * Probing for ARMV7_TICK is known to produce unreliable results,
+-     * so we will only use the feature when the user explicitly enables
+-     * it with OPENSSL_armcap.
+-     */
+-
+-    sigaction(SIGILL, &ill_oact, NULL);
+-    sigprocmask(SIG_SETMASK, &oset, NULL);
+-
+-# ifdef __aarch64__
+-    if (OPENSSL_armcap_P & ARMV8_CPUID)
+-        OPENSSL_arm_midr = _armv8_cpuid_probe();
+-
+-    if ((MIDR_IS_CPU_MODEL(OPENSSL_arm_midr, ARM_CPU_IMP_ARM, ARM_CPU_PART_CORTEX_A72) ||
+-         MIDR_IS_CPU_MODEL(OPENSSL_arm_midr, ARM_CPU_IMP_ARM, ARM_CPU_PART_N1)) &&
+-        (OPENSSL_armcap_P & ARMV7_NEON)) {
+-            OPENSSL_armv8_rsa_neonized = 1;
+-    }
+-# endif
+ }
+ #endif
+diff --git a/crypto/armv4cpuid.pl b/crypto/armv4cpuid.pl
+index 8991fd4a..61628110 100644
+--- a/crypto/armv4cpuid.pl
++++ b/crypto/armv4cpuid.pl
+@@ -293,7 +293,7 @@ atomic_add_spinlock:
+ #endif
+ 
+ .comm	OPENSSL_armcap_P,4,4
+-.hidden	OPENSSL_armcap_P
++.global	OPENSSL_armcap_P
+ ___
+ 
+ print $code;

--- a/src/openssl.mk
+++ b/src/openssl.mk
@@ -24,6 +24,7 @@ $(PKG)_MAKE = $(MAKE) -C '$(1)' -j '$(JOBS)'\
         AR='$(TARGET)-ar' \
         RC='$(TARGET)-windres' \
         CROSS_COMPILE='$(TARGET)-' \
+        RCFLAGS='-I$(PREFIX)/$(TARGET)/include' \
         $(if $(BUILD_SHARED), ENGINESDIR='$(PREFIX)/$(TARGET)/bin/engines')
 
 define $(PKG)_BUILD
@@ -33,8 +34,9 @@ define $(PKG)_BUILD
     rm -fv '$(PREFIX)/$(TARGET)/'*/{libcrypto*,libssl*}
     rm -fv '$(PREFIX)/$(TARGET)/lib/pkgconfig/'{libcrypto*,libssl*,openssl*}
 
+    # MOREINFO shall we choose --api=... explicitly? In other words, is 3.x any better than 1.0.2?
     cd '$(1)' && CC='$(TARGET)-gcc' RC='$(TARGET)-windres' ./Configure \
-        @openssl-target@ \
+        mingw-arm \
         zlib \
         $(if $(BUILD_STATIC),no-module no-,)shared \
         no-capieng \
@@ -43,6 +45,3 @@ define $(PKG)_BUILD
     $($(PKG)_MAKE) build_sw
     $($(PKG)_MAKE) install_sw
 endef
-
-$(PKG)_BUILD_i686-w64-mingw32   = $(subst @openssl-target@,mingw,$($(PKG)_BUILD))
-$(PKG)_BUILD_x86_64-w64-mingw32 = $(subst @openssl-target@,mingw64,$($(PKG)_BUILD))


### PR DESCRIPTION
Added mingw-arm configuration to OpenSSL, disabling capability probing.

Dependents unblocked:
* dcmtk
* freetds
* gsoap
* libdvdetect (needed own tuning)
* libevent
* liboauth
* neon