### PR TITLE
libmodplug + smpeg2: add intrinsic flags, SDL(2) + subprojects: building with no errors (no OpenGL(ES))

### DIFF
--- a/src/libmodplug.mk
+++ b/src/libmodplug.mk
@@ -19,7 +19,7 @@ endef
 define $(PKG)_BUILD
     cd '$(1)' && ./configure \
         $(MXE_CONFIGURE_OPTS)
-    $(MAKE) -C '$(1)' -j '$(JOBS)' install
+    $(MAKE) -C '$(1)' -j '$(JOBS)' LDFLAGS='`$(MXE_INTRINSIC_SH) {{aeabi_{,u}{i,l}divmod,{,u}divmodsi4}.S,{,u}divmoddi4.c}.obj chkstk.S.obj`' install
 
     '$(TARGET)-gcc' \
         -W -Wall -ansi -pedantic \

--- a/src/sdl.mk
+++ b/src/sdl.mk
@@ -23,6 +23,7 @@ define $(PKG)_BUILD
     $(SED) -i 's,-mwindows,-lwinmm -mwindows,' '$(1)/configure'
     cd '$(1)' && ./configure \
         $(MXE_CONFIGURE_OPTS) \
+		--disable-video-opengl \
         --enable-threads \
         --enable-directx \
         --disable-stdio-redirect

--- a/src/smpeg2.mk
+++ b/src/smpeg2.mk
@@ -29,7 +29,7 @@ define $(PKG)_BUILD
         --disable-gtk-player \
         --disable-opengl-player \
         CFLAGS='-ffriend-injection -Wno-narrowing'
-    $(MAKE) -C '$(1)' -j '$(JOBS)' install $(MXE_DISABLE_CRUFT)
+    $(MAKE) -C '$(1)' -j '$(JOBS)' LDFLAGS='`$(MXE_INTRINSIC_SH) {{aeabi_{,u}{i,l}divmod,{,u}divmodsi4}.S,{,u}divmoddi4.c}.obj chkstk.S.obj`' install $(MXE_DISABLE_CRUFT)
 
     '$(TARGET)-gcc' \
         -W -Wall -Werror -std=c99 -pedantic \


### PR DESCRIPTION
Fixes building libmodplug, smpeg2, SDL, and the subprojects of SDL(2) (image, mixer, ttf)