### PR TITLE
Export static libraries as public dependencies in gnutls, fixing wget

### DIFF
--- a/src/gnutls-1-fixes.patch
+++ b/src/gnutls-1-fixes.patch
@@ -1,0 +1,13 @@
+diff --git a/lib/gnutls.pc.in b/lib/gnutls.pc.in
+index 7cdedda5..094738fe 100644
+--- a/lib/gnutls.pc.in
++++ b/lib/gnutls.pc.in
+@@ -18,7 +18,7 @@ Name: GnuTLS
+ Description: Transport Security Layer implementation for the GNU system
+ URL: https://www.gnutls.org/
+ Version: @VERSION@
+-Libs: -L${libdir} -lgnutls
++Libs: -L${libdir} -lgnutls @GNUTLS_LIBS_PRIVATE@
+ Libs.private: @LIBINTL@ @LIBSOCKET@ @INET_PTON_LIB@ @LIBPTHREAD@ @LIB_SELECT@ @TSS_LIBS@ @GMP_LIBS@ @LIBUNISTRING@ @LIBATOMIC_LIBS@ @GNUTLS_LIBS_PRIVATE@
+ @GNUTLS_REQUIRES_PRIVATE@
+ Cflags: -I${includedir}

--- a/src/gnutls.mk
+++ b/src/gnutls.mk
@@ -27,6 +27,7 @@ define $(PKG)_BUILD
         --disable-doc \
         --disable-tests \
         --enable-local-libopts \
+        --enable-ssl3-support \
         --without-p11-kit \
         --disable-silent-rules
     $(MAKE) -C '$(BUILD_DIR)' -j '$(JOBS)'


### PR DESCRIPTION
Private dependencies of `libgnutls`, per the `GNUTLS_LIBS_PRIVATE` config variable, are `-lcrypt32 -lncrypt -lbcrypt`.
All of them are static libraries and need to be linked into the eventual executable (a "diamond dependency" prevention rule enforced by `libtool`).
Making them public in the pkgconfig file fixes `wget` (and potentially other clients of `libgnutls`).
Requesting a review mostly to share the analysis.

SSL3.0 is added as a bonus feature.