### PR TITLE
Cross-compile Perl

### DIFF
--- a/src/perl-1-fixes.patch
+++ b/src/perl-1-fixes.patch
@@ -1,0 +1,127 @@
+diff --git a/dist/IO/poll.h b/dist/IO/poll.h
+index 08de2506..c9a2a9ae 100644
+--- a/dist/IO/poll.h
++++ b/dist/IO/poll.h
+@@ -10,7 +10,7 @@
+ #ifndef POLL_H
+ #  define POLL_H
+ 
+-#if (defined(HAS_POLL) && defined(I_POLL)) || defined(POLLWRBAND)
++#if 0
+ #  include <poll.h>
+ #elif (defined(HAS_POLL) && defined(I_SYS_POLL))
+ #  include <sys/poll.h>
+diff --git a/ext/Errno/Errno_pm.PL b/ext/Errno/Errno_pm.PL
+index ee2f4a3a..b91988ba 100644
+--- a/ext/Errno/Errno_pm.PL
++++ b/ext/Errno/Errno_pm.PL
+@@ -122,7 +122,7 @@ sub get_files {
+ 	# Some Linuxes have weird errno.hs which generate
+ 	# no #file or #line directives
+ 	($linux_errno_h) = grep { -e $_ } map { "$_/errno.h" }
+-	    "$sysroot/usr/include", "$sysroot/usr/local/include",
++	    "$sysroot/include", "$sysroot/usr/local/include",
+ 	    split / / => $Config{locincpth};
+     }
+ 
+diff --git a/win32/win32.h b/win32/win32.h
+index fea567f7..0ab69bd0 100644
+--- a/win32/win32.h
++++ b/win32/win32.h
+@@ -333,9 +333,9 @@ typedef struct
+ /* Note: PERLIO_FILE_ptr/base/cnt are not actually used for GCC or <VS2015
+  * since FILE_ptr/base/cnt do the same thing anyway but it doesn't hurt to
+  * define them all here for completeness. */
+-#define PERLIO_FILE_flag_RD _IOREAD /* 0x001 */
+-#define PERLIO_FILE_flag_WR _IOWRT  /* 0x002 */
+-#define PERLIO_FILE_flag_RW _IORW   /* 0x080 */
++#define PERLIO_FILE_flag_RD 0x001 /* _IOREAD */
++#define PERLIO_FILE_flag_WR 0x002 /* _IOWRT  */
++#define PERLIO_FILE_flag_RW 0x080 /* _IORW   */
+ #define PERLIO_FILE_ptr(f)  ((f)->_ptr)
+ #define PERLIO_FILE_base(f) ((f)->_base)
+ #define PERLIO_FILE_cnt(f)  ((f)->_cnt)
+@@ -666,7 +666,7 @@ EXTERN_C _CRTIMP ioinfo* __pioinfo[];
+ #endif
+ 
+ /* since we are not doing a dup2(), this works fine */
+-#define _set_osfhnd(fh, osfh) (void)(_osfhnd(fh) = (intptr_t)osfh)
++#define _set_osfhnd_suppress(fh, osfh) (void)(_osfhnd(fh) = (intptr_t)osfh)
+ 
+ #endif /* PERL_CORE */
+ 
+diff --git a/win32/win32.c b/win32/win32.c
+index 78a4c856..0bfd6e5c 100644
+--- a/win32/win32.c
++++ b/win32/win32.c
+@@ -1,3 +1,4 @@
++#ifndef USE_CROSS_COMPILE
+ /* WIN32.C
+  *
+  * (c) 1995 Microsoft Corporation. All rights reserved.
+@@ -526,8 +527,8 @@ Perl_my_popen(pTHX_ const char *cmd, const char *mode)
+     return win32_popen(cmd, mode);
+ }
+ 
+-long
++I32
+ Perl_my_pclose(pTHX_ PerlIO *fp)
+ {
+     return win32_pclose(fp);
+ }
+@@ -5289,3 +5290,4 @@ Perl_sys_intern_dup(pTHX_ struct interp_intern *src, struct interp_intern *dst)
+ }
+ #  endif /* USE_ITHREADS */
+ #endif /* HAVE_INTERP_INTERN */
++#endif /* USE_CROSS_COMPILE */
+diff --git a/win32/win32sck.c b/win32/win32sck.c
+index ef5c6821..6c490af7 100644
+--- a/win32/win32sck.c
++++ b/win32/win32sck.c
+@@ -1,3 +1,4 @@
++#ifndef USE_CROSS_COMPILE
+ /* win32sck.c
+  *
+  * (c) 1995 Microsoft Corporation. All rights reserved. 
+@@ -22,7 +23,7 @@
+ #include "EXTERN.h"
+ #include "perl.h"
+ 
+-#include "Win32iop.h"
++#include "win32iop.h"
+ #include <sys/socket.h>
+ #include <fcntl.h>
+ #include <sys/stat.h>
+@@ -985,3 +986,4 @@ win32_savecopyservent(struct servent*d, struct servent*s, const char *proto)
+ }
+ 
+ 
++#endif /* USE_CROSS_COMPILE */
+diff --git a/win32/win32thread.c b/win32/win32thread.c
+index 1f327d6d..e9f5cb61 100644
+--- a/win32/win32thread.c
++++ b/win32/win32thread.c
+@@ -1,3 +1,4 @@
++#ifndef USE_CROSS_COMPILE
+ #include "EXTERN.h"
+ #include "perl.h"
+ 
+@@ -35,3 +36,4 @@ Perl_get_context(void)
+     return NULL;
+ #endif
+ }
++#endif /* USE_CROSS_COMPILE */
+diff --git a/win32/fcrypt.c b/win32/fcrypt.c
+index 219f4f0b..367552d2 100644
+--- a/win32/fcrypt.c
++++ b/win32/fcrypt.c
+@@ -1,3 +1,4 @@
++#ifndef USE_CROSS_COMPILE
+ /* fcrypt.c */
+ /* Copyright (C) 1993 Eric Young - see README for more details */
+ #include <stdio.h>
+@@ -591,3 +592,4 @@ body(	unsigned long *out0,
+         return(0);
+         }
+ 
++#endif /* USE_CROSS_COMPILE */

--- a/src/perl-cross-1-fixes.patch
+++ b/src/perl-cross-1-fixes.patch
@@ -1,0 +1,72 @@
+diff --git a/Makefile b/Makefile
+index 40dbeef7..da385b9a 100644
+--- a/Makefile
++++ b/Makefile
+@@ -25,7 +25,7 @@ src += perly.c pp.c pp_hot.c pp_ctl.c pp_sys.c regcomp.c regexec.c
+ src += utf8.c sv.c taint.c toke.c util.c deb.c run.c universal.c
+ src += pad.c globals.c keywords.c perlio.c perlapi.c numeric.c
+ src += mathoms.c locale.c pp_pack.c pp_sort.c caretx.c dquote.c $(time64.c)
+-src += pp_type.c xsutils.c # cperl
++src += pp_type.c xsutils.c win32.c win32thread.c win32sck.c fcrypt.c
+ src += $(wildcard builtin.c)
+ src += $(mallocsrc)
+ 
+@@ -138,15 +138,15 @@ regen_perly:
+ 
+ ifeq ($(useshrplib),true)
+ ifeq ($(soname),)
+-perl$x: LDFLAGS += -Wl,-rpath,$(archlib)/CORE
++perl$x: LDFLAGS += 
+ endif
+ endif # or should it be "else"?
+-perl$x: LDFLAGS += -Wl,-E
++perl$x: LDFLAGS += -Wl,--export-all-symbols
+ 
+ perl$x: perlmain$o $(LIBPERL) $(static_modules) static.list ext.libs
+ 	$(eval extlibs=$(shell cat ext.libs))
+ 	$(eval statars=$(shell cat static.list))
+-	$(CC) $(LDFLAGS) -o $@ $(filter %$o,$^) $(LIBPERL) $(statars) $(LIBS) $(extlibs)
++	$(CC) $(LDFLAGS) -o $@ $(filter %$o,$^) -L$(PATCHED_PERL_DIR) -lperl $(statars) $(LIBS) $(extlibs)
+ 
+ %$o: %.c config.h
+ 	$(CC) $(CFLAGS) -c -o $@ $<
+@@ -186,7 +186,7 @@ endif
+ 
+ ifeq ($(useshrplib),true)
+ $(LIBPERL):
+-	$(CC) $(LDDLFLAGS) -o $@ $(filter %$o,$^) $(LIBS)
++	$(CC) $(LDDLFLAGS) -Wl,--export-all-symbols -Wl,--out-implib=$(PATCHED_PERL_DIR)/libperl.a -o $@ $(filter %$o,$^) $(LIBS)
+ else
+ $(LIBPERL):
+ 	$(AR) cru $@ $(filter %$o,$^)
+@@ -427,17 +427,10 @@ install:
+ install.perl: installperl | miniperl$X
+ 	./miniperl_top installperl --destdir=$(DESTDIR) $(INSTALLFLAGS) $(STRIPFLAGS)
+ 	-@test ! -s extras.lst || $(MAKE) extras.install
+-ifneq ($(perlname),perl)
+-	-rm -f $(DESTDIR)$(installbin)/$(perlname)$(version)
+-	ln -sf $(perlname) $(DESTDIR)$(installbin)/perl
+-else
+-	-rm -f $(DESTDIR)$(installbin)/$(perlname)$(version)
+-endif
+ 
+ install.sym: # deprecated
+ 
+ install.man: installman pod/perltoc.pod | miniperl$X
+-	./miniperl_top installman --destdir=$(DESTDIR) $(INSTALLFLAGS)
+ 
+ # ---[ testpack ]---------------------------------------------------------------
+ .PHONY: testpack
+diff --git a/cnf/configure_tool.sh b/cnf/configure_tool.sh
+index ca495c77..4550c2a0 100644
+--- a/cnf/configure_tool.sh
++++ b/cnf/configure_tool.sh
+@@ -154,7 +154,7 @@ define _exe ''
+ 
+ # Used only for modules
+ define cccdlflags '-fPIC -Wno-unused-function'
+-define ccdlflags '-Wl,-E'
++define ccdlflags '-Wl,--export-all-symbols'
+ 
+ # Misc flags setup
+ predef lddlflags "-shared"	# modules

--- a/src/perl-cross.mk
+++ b/src/perl-cross.mk
@@ -1,0 +1,15 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+
+PKG             := perl-cross
+$(PKG)_WEBSITE  := https://arsv.github.io/perl-cross/
+$(PKG)_DESCR    := Cross-compiling perl
+$(PKG)_IGNORE   :=
+$(PKG)_VERSION  := 1.4
+$(PKG)_CHECKSUM := cc5acaab4defbcee7c107fd417d30412f3cdae5be8adf1fc22641485823b57ee
+$(PKG)_SUBDIR   := $(PKG)-$($(PKG)_VERSION)
+$(PKG)_FILE     := $(PKG)-$($(PKG)_VERSION).tar.gz
+$(PKG)_URL      := https://github.com/arsv/$(PKG)/archive/refs/tags/$($(PKG)_VERSION).tar.gz
+$(PKG)_TYPE     := source-only
+
+# perl-cross provides configure script, top-level Makefile and some auxiliary files for perl,
+# with the primary emphasis on cross-compiling the source.

--- a/src/perl.mk
+++ b/src/perl.mk
@@ -1,0 +1,134 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+
+PKG             := perl
+$(PKG)_WEBSITE  := https://www.perl.org
+$(PKG)_IGNORE   :=
+$(PKG)_VERSION  := 5.36.0
+$(PKG)_CHECKSUM := e26085af8ac396f62add8a533c3a0ea8c8497d836f0689347ac5abd7b7a4e00a
+$(PKG)_SUBDIR   := $(PKG)-$($(PKG)_VERSION)
+$(PKG)_FILE     := $($(PKG)_SUBDIR).tar.gz
+$(PKG)_URL      := https://www.cpan.org/src/5.0/$($(PKG)_FILE)
+$(PKG)_DEPS     := cc pthreads perl-cross
+
+$(PKG)_TARGET_EXTRAS = win32.c win32thread.c win32sck.c fcrypt.c
+$(PKG)_VERSED_FOLDER = perl5/$($(PKG)_VERSION)
+$(PKG)_PUBLIC_HEADER = 
+
+define $(PKG)_BUILD
+    # hacky, but, OTOH, avoiding wildcards
+    cp -r --no-preserve=all '$(SOURCE_DIR)' '$(BUILD_DIR)'
+    $(call PREPARE_PKG_SOURCE,perl-cross,'$(SOURCE_DIR)')
+    cd '$(SOURCE_DIR)' && mv '$(perl-cross_SUBDIR)' '$(perl_SUBDIR)' && cp -r '$(perl_SUBDIR)' '$(BUILD_DIR)/'
+    
+    $(foreach script, \
+            cflags makedepend makedepend_file Makefile Makefile.config \
+            metaconfig myconfig runtests Policy_sh pod/Makefile config_h \
+        , chmod 0755 '$(BUILD_DIR)/$(perl_SUBDIR)/$(script).SH'; )
+
+    $(foreach winsrc,$($(PKG)_TARGET_EXTRAS), \
+        ln -s '$(BUILD_DIR)/$(perl_SUBDIR)/win32/$(winsrc)' '$(BUILD_DIR)/$(perl_SUBDIR)/'; )
+
+    # prior to manual setup, ccflags was:
+    # ccflags='--sysroot=$(PREFIX)/$(TARGET) -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64'
+    
+    # some of the flags are well-intended but only effective in ./Configure rather than
+    # the (perl-cross originating) ./configure -- kept as hints for any further porters
+
+    # patch sets in `perl` and `perl-cross` are related and should be applied together!
+
+    cd '$(BUILD_DIR)/$(perl_SUBDIR)' && X=.exe $(SHELL) ./configure \
+        '--prefix=$(PREFIX)/$(TARGET)' \
+        '--sysroot=$(PREFIX)/$(TARGET)' \
+        '--build=$(BUILD)' \
+        '--target=$(TARGET)' \
+        '--with-cc=$(TARGET)-gcc' \
+        '--use-threads' \
+        '--hints=mswin32' '-Dosname=MSWin32' \
+        '-Duseshrplib' '-Ddlext=.dll' '-Dexe_ext=.exe' '-Dallstatic=0' '-Dlibperl=perl.dll' \
+        '-Dshrpldflags=-Wl,--out-implib=$(BUILD_DIR)/$(perl_SUBDIR)/libperl.a' \
+        '-Dlinklibperl=-L$(BUILD_DIR)/$(perl_SUBDIR) -lperl' \
+        '-Dusemultiplicity=define' \
+        '-Dcharsize=1' '-Dshortsize=2' '-Dintsize=4' '-Dlongsize=4' \
+        '-Ddoublesize=8' '-Dlongdblsize=12' '-Dlonglongsize=8' \
+        '-Dptrsize=4' '-Dsizesize=4' '-Dfpossize=8' '-Dlseeksize=8' \
+        '-Dtimesize=64' '-Duvsize=4' '-Divsize=4' '-Dnvsize=8' \
+        '-Dd_nanosleep=undef' '-Duseithreads=undef' \
+        '-Ddirentrytype=struct direct' \
+        '-Ddrand01=Perl_drand48()' \
+        '-Dccflags=-D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -D__MINGW32__ -DPERLDLL \
+            -DPERL_USE_SAFE_PUTENV \
+            -isystem $(BUILD_DIR)/$(perl_SUBDIR)/win32 \
+            -isystem $(BUILD_DIR)/$(perl_SUBDIR)/win32/include \
+            -isystem $(PREFIX)/$(TARGET)/include \
+            --sysroot=$(PREFIX)/$(TARGET)' \
+        '-Dccdlflags=-Wl,--export-all-symbols' \
+        '-Dldflags=-L$(PREFIX)/$(TARGET)/lib -lcomctl32 -lgdi32 -ladvapi32 \
+            -luser32 -lwinspool -lshell32 -lole32 -loleaut32 \
+            -lnetapi32 -luuid -lws2_32 -lmpr -lwinmm -lversion'
+
+    $(MAKE) -C '$(BUILD_DIR)/$(perl_SUBDIR)' -j '$(JOBS)' \
+            PATCHED_PERL_DIR='$(BUILD_DIR)/$(perl_SUBDIR)'
+    
+    # passing absolute paths to install targets leads to barbaric locations -- such
+    # as "usr/armv7-w64-mingw32/home/dev/Code/mxe-shared/usr/armv7-w64-mingw32/lib"
+    # therefore make install is commented out and replaced with explicit $(INSTALL)
+    # (future generations MAY want to fix it):
+    # $(MAKE) -C '$(BUILD_DIR)/$(perl_SUBDIR)' DESTDIR='$(PREFIX)/$(TARGET)' \
+    #         X=.exe installbin=/bin install
+
+    $(INSTALL) -d '$(PREFIX)/$(TARGET)/lib/$($(PKG)_VERSED_FOLDER)'
+    $(INSTALL) -d '$(PREFIX)/$(TARGET)/bin/$($(PKG)_VERSED_FOLDER)'
+
+    cd '$(BUILD_DIR)/$(perl_SUBDIR)/lib' && \
+        ( \
+            find -name '*.pl'; \
+            find -name '*.pm'; \
+            find -name '*.ld'; \
+            find -name '*.txt' \
+            find -name '*.yml' \
+            find -name '*.dd'; \
+            echo ExtUtils/MANIFEST.SKIP; \
+            echo ExtUtils/typemap; \
+            echo ExtUtils/xsubpp; \
+            echo unicore/version; \
+        ) | while read path; do \
+        $(INSTALL) -m 644 -D "$$path" \
+            "$(PREFIX)/$(TARGET)/bin/$($(PKG)_VERSED_FOLDER)/$$path"; \
+    done
+
+    $(INSTALL) -m 644 '$(BUILD_DIR)/$(perl_SUBDIR)/perl.exe' \
+            '$(PREFIX)/$(TARGET)/bin/$($(PKG)_VERSED_FOLDER)'
+    $(INSTALL) -m 644 '$(BUILD_DIR)/$(perl_SUBDIR)/perl.dll' \
+            '$(PREFIX)/$(TARGET)/bin/$($(PKG)_VERSED_FOLDER)'
+    $(INSTALL) -m 644 '$(BUILD_DIR)/$(perl_SUBDIR)/libperl.a' \
+            '$(PREFIX)/$(TARGET)/lib/$($(PKG)_VERSED_FOLDER)'
+
+    ln -sf '$($(PKG)_VERSED_FOLDER)/libperl.a' \
+            '$(PREFIX)/$(TARGET)/bin'
+    ln -sf '$($(PKG)_VERSED_FOLDER)/perl.dll' \
+            '$(PREFIX)/$(TARGET)/bin'
+    ln -sf '$($(PKG)_VERSED_FOLDER)/perl$($(PKG)_VERSION).exe' \
+            '$(PREFIX)/$(TARGET)/bin'
+    ln -sf '$($(PKG)_VERSED_FOLDER)/perl.exe' \
+            '$(PREFIX)/$(TARGET)/bin'
+
+    # the location is not exactly canonical, but likely functional (Perl files
+    # aren't executable on Windows, therefore PATH won't be considered anyway)
+    cd '$(BUILD_DIR)/$(perl_SUBDIR)/utils' \
+        && $(INSTALL) -m 644 --target-directory '$(PREFIX)/$(TARGET)/bin/perl5/' \
+            `ls | grep -v PL | grep -v Makefile`
+
+    # ditto -- foreach(app|embedding a Perl interpreter) app.heads(up)
+    $(INSTALL) -d \
+            '$(PREFIX)/$(TARGET)/include/$($(PKG)_SUBDIR)/'
+    ls '$(BUILD_DIR)/$(perl_SUBDIR)/*.h' | while read path; do \
+        $(INSTALL) -m 644 "$$path" \
+            '$(PREFIX)/$(TARGET)/include/$($(PKG)_SUBDIR)/'; \
+    done
+    ln -sf $($(PKG)_SUBDIR) \
+        '$(PREFIX)/$(TARGET)/include/perl5'
+
+    # unlikely, but certain scripts might request "site_perl"
+    # even outside a CGI environment, so let's have it anyway
+    $(INSTALL) -d '$(PREFIX)/$(TARGET)/bin/perl5/site_perl/$($(PKG)_VERSION)'
+endef


### PR DESCRIPTION
A combination of:
* https://perldoc.perl.org/perlwin32
* https://arsv.github.io/perl-cross/
* manual installation script to fine-tune the installation paths.

Hellish. Will likely be revisited on first target Perl use.

On the bright side, linking is dynamic => Perl interpreter embedding is supported.