### PR TITLE
More subsystem/deployment prerequisites

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 /log*/
 /pkg
 /wip/
+/out
 /tmp-*
 /.ccache
 

--- a/Makefile
+++ b/Makefile
@@ -806,6 +806,7 @@ $(PREFIX)/$(3)/installed/$(1): $(PKG_MAKEFILES) \
 	                && CUTOFF='$(MXE_CUTOFF_FILE)' \
 	                    PREFIX='$(PREFIX)' \
 	                    BUILD='$(BUILD)' \
+	                    VERSION='$($(1)_VERSION)' \
 	                $(SHELL) '$(PWD)/mxe.postbuild.sh' '$(1)' '$(3)' \
 	               ) &> '$(LOG_DIR)/$(TIMESTAMP)/$(1)_$(3)'; then \
 	            echo; \

--- a/mxe.postbuild.sh
+++ b/mxe.postbuild.sh
@@ -1,15 +1,67 @@
 #!/bin/bash
 
+set -e
+
 # avoid specific action names like "archive" or "codesign"
 # -- all package grooming for deployment will happen here
+TARGET="${2}"
 TMPDIR="tmp-${1}_${2}-postbuild"
 mkdir -p "$TMPDIR"
 
-# TODO inject VERSION and dependencies (with own versions)
+# The Debian convention is "Foo_ver[-rev]_arch"
+FOONAME=`echo ${1} | tr _ -`
+FOO_VER=`echo $VERSION | tr _ -`
+
+OUTDIR="./out/${2}"
+TGZDIR="$OUTDIR/tgz"
+ZIPDIR="$OUTDIR/zip"
+DEBDIR="$OUTDIR/deb"
+
+mkdir -p "$TGZDIR/latest"
+mkdir -p "$ZIPDIR/latest"
+mkdir -p "$DEBDIR/latest"
+
+# The target (Makefile's $(3) turned ${2})  won't be sanitized:
+# 1. it's the last component anyway ("cut -d '_' 3-" will work),
+# 2. packages for different targets are never deployed together;
+# 3. unfortunately, x86_64 traditionally contains an underscore.
+Q_NAME="${FOONAME}_${FOO_VER}_${2}" # =qualified (absolute) name
+LATEST="latest/${FOONAME}_${2}" # =symbolic link to latest-built
+
+OUTTGZ="$TGZDIR/$Q_NAME.tar.gz"
+OUTZIP="$ZIPDIR/$Q_NAME.zip"
+OUTDEB="$DEBDIR/$Q_NAME.deb"    # not built yet: needs dep/graph
+
+# tape archives are compressed in streaming mode for efficiency
+# (dictionary reuse). first we append into them, then compress.
+TMPTAR="$TMPDIR/$VERSION.tar" # ($TARGET is already in $TMPDIR)
+TMPZIP="$TMPDIR/$VERSION.lst" # proto-zip is simply a file list
+
+# absolute paths for access inside pushd-popd
+ABSTAR=`realpath "$TMPTAR"`
+ABSZIP=`realpath "$OUTZIP"`
+ABSLST=`realpath "$TMPZIP"`
+
+# TODO inject dependencies (with their own versions)
 # ROADMAP fix non-comparable versions (e.g. commit hashes)
+
+# Now: we are only interested in files in $PREFIX/$TARGET,
+# and only if $TARGET != $BUILD:
+if [ "x$TARGET" != "x$BUILD" ]; then
+    echo Locating tar:
+    which tar
+    echo Locating zip:
+    which zip
+    echo Locating gzip:
+    which gzip
+
+    rm -f "$TMPTAR"; touch "$TMPTAR"
+    rm -f "$TMPZIP"; touch "$TMPZIP"
+fi
 
 find "$PREFIX" -newer "$CUTOFF" | while read installable
 do
+    # (We still sign PE32 binaries everywhere we find them.)
     ext="${installable##*.}"
     case "$ext" in
     "exe" | "dll")
@@ -18,10 +70,33 @@ do
         ;;
     esac
 
+    if [ "x$TARGET" != "x$BUILD" ]; then
+        innerpath=`realpath "$installable" "--relative-to=$PREFIX/$TARGET"`
+        if [ 'x..' != "x`echo $innerpath | cut -d '/' -f 1`" ]; then
+            pushd "$PREFIX/$TARGET"
+                tar --dereference --no-recursion --append -f "$ABSTAR" "$innerpath"
+            popd
+            echo "$innerpath" | tee >> "$TMPZIP"
+        fi
+    fi
+
     # TODO add to <pkg>.tar.gz
     # TODO add to <pkg>.deb
 done
 
+if [ -e "$TMPTAR" ]; then
+    gzip "$TMPTAR" -c > "$OUTTGZ"
+    ln -sf `realpath "$OUTTGZ" "--relative-to=$TGZDIR/latest"` "$TGZDIR/$LATEST.tar.gz"
+fi
+
+if [ -e "$TMPZIP" ]; then
+    pushd "$PREFIX/$TARGET"
+        # pack a list of files
+        zip "$ABSZIP" -@ < "$ABSLST"
+    popd
+    ln -sf `realpath "$OUTZIP" "--relative-to=$ZIPDIR/latest"` "$ZIPDIR/$LATEST.zip"
+fi
+
 # be conservative -- only remove (potentially) expected files here
-rm "$TMPDIR"/signed*
+rm -f "$TMPDIR"/signed* "$TMPTAR" "$TMPZIP"
 rmdir "$TMPDIR"

--- a/src/drmingw.mk
+++ b/src/drmingw.mk
@@ -1,0 +1,26 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+
+PKG             := drmingw
+$(PKG)_WEBSITE  := https://github.com/jrfonseca/drmingw
+$(PKG)_DESCR    := Postmortem debugging tools for MinGW
+$(PKG)_IGNORE   :=
+$(PKG)_VERSION  := 0.9.9
+$(PKG)_CHECKSUM := 268c7c30db84547da76f9f22d636fa9e010f745e0e8d125e7b44ddb409a918ae
+$(PKG)_GH_CONF  := jrfonseca/drmingw/releases
+$(PKG)_DEPS     := cc libdwarf-0-3-4 zlib
+
+define $(PKG)_BUILD
+    # use distro-integrated library versions instead of resolving Git submodules
+    # $(SED) -i 's!include (libdwarf.cmake)!find_package(libdwarf CONFIG REQUIRED)!' \
+    #     '$(SOURCE_DIR)/thirdparty/CMakeLists.txt'
+    $(SED) -i 's!include (zlib.cmake)!add_library(zlib SHARED IMPORTED)\nfind_library(ZLIB_PATH z HINTS "$${ZLIB_HINT}")\nset_target_properties(zlib PROPERTIES IMPORTED_LOCATION "$(ZLIB_PATH)")!' \
+        '$(SOURCE_DIR)/thirdparty/CMakeLists.txt'
+    $(call PREPARE_PKG_SOURCE,libdwarf-0-3-4,'$(SOURCE_DIR)/thirdparty/')
+    rmdir '$(SOURCE_DIR)/thirdparty/libdwarf' && ln -sf './$(libdwarf-0-3-4_SUBDIR)' '$(SOURCE_DIR)/thirdparty/libdwarf'
+
+    cd '$(BUILD_DIR)' && '$(TARGET)-cmake' '$(SOURCE_DIR)' \
+        -DZLIB_HINT:String=$(PREFIX)/$(TARGET)/lib
+
+    $(MAKE) -C '$(BUILD_DIR)' -j '$(JOBS)'
+    $(MAKE) -C '$(BUILD_DIR)' -j 1 install
+endef

--- a/src/libdwarf-0-3-4.mk
+++ b/src/libdwarf-0-3-4.mk
@@ -1,0 +1,13 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+
+PKG             := libdwarf-0-3-4
+$(PKG)_WEBSITE  := https://github.com/davea42/libdwarf-code
+$(PKG)_DESCR    := Tools to access DWARF symbol and debugging information
+$(PKG)_IGNORE   :=
+$(PKG)_VERSION  := 0.3.4
+$(PKG)_CHECKSUM := 72c5595f31815bed856d09ad344bf4aab8f3ac887e25e41ae6f3a3b27ce31353
+$(PKG)_GH_CONF  := davea42/libdwarf-code/tags,v
+$(PKG)_TYPE     := source-only
+
+# 0.5.0 is the latest and greatest stable release as of now, Feb 2023.
+# However, drmingw uses 0.3.4, which we integrate as a source package.

--- a/src/libdwarf.mk
+++ b/src/libdwarf.mk
@@ -1,0 +1,20 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+
+PKG             := libdwarf
+$(PKG)_WEBSITE  := https://github.com/davea42/libdwarf-code
+$(PKG)_DESCR    := Tools to access DWARF symbol and debugging information
+$(PKG)_IGNORE   :=
+$(PKG)_VERSION  := 0.5.0
+$(PKG)_CHECKSUM := 5cc5e97980fbe26832577d49061b2719b829ba72b97f30015670e4c2d0688906
+$(PKG)_GH_CONF  := davea42/libdwarf-code/releases,v
+$(PKG)_DEPS     := cc
+
+define $(PKG)_BUILD
+    cd '$(BUILD_DIR)' && '$(TARGET)-cmake' '$(SOURCE_DIR)' \
+        -DHAVE_UNUSED_ATTRIBUTE:Bool=OFF
+    $(MAKE) -C '$(BUILD_DIR)' -j '$(JOBS)'
+    $(MAKE) -C '$(BUILD_DIR)' -j 1 install
+endef
+
+# 0.5.0 is the latest and greatest stable release as of now, Feb 2023.
+# However, drmingw uses 0.3.4, which we integrate as a source package.

--- a/src/wine-tools.mk
+++ b/src/wine-tools.mk
@@ -1,0 +1,50 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+
+PKG             := wine-tools
+$(PKG)_WEBSITE  := http://simplesystems.org/libtiff/
+$(PKG)_DESCR    := message (*.mc) compiler from Wine
+$(PKG)_IGNORE   := $(wine_IGNORE)
+$(PKG)_VERSION  := $(wine_VERSION)
+$(PKG)_CHECKSUM := $(wine_CHECKSUM)
+$(PKG)_SUBDIR   := $(wine_SUBDIR)
+$(PKG)_FILE     := $(wine_FILE)
+$(PKG)_URL      := $(wine_URL)
+$(PKG)_TARGETS  := $(BUILD)
+$(PKG)_DEPS     := wine
+
+# Wine configuration takes ages, but its tools are lightweight to build.
+# We keep them in a single package and build slightly more than we need.
+# The tools are linked statically and need no Wine-provided libraries --
+# but watch for missing includes once actual projects start using them.
+
+define $(PKG)_BUILD
+    $(call PREPARE_PKG_SOURCE,wine,'$(SOURCE_DIR)')
+    cd '$(SOURCE_DIR)/$(wine_SUBDIR)' && ./configure \
+        --prefix=$(wine_DESTDIR) \
+        --disable-win16 \
+        --disable-tests \
+        --enable-win64
+    $(MAKE) -C '$(SOURCE_DIR)/$(wine_SUBDIR)' -j '$(JOBS)' \
+        tools/widl/install \
+        tools/wmc/install \
+        tools/wrc/install \
+        nls/install
+
+    #
+    ################################
+    ##         widl usage         ##
+    ################################
+    '$(wine_TOOLDIR)/widl' --help
+
+    #
+    ################################
+    #           wmc usage         ##
+    ################################
+    '$(wine_TOOLDIR)/wmc' --help
+
+    #
+    ################################
+    #           wrc usage         ##
+    ################################
+    '$(wine_TOOLDIR)/wrc' --help
+endef

--- a/src/wine.mk
+++ b/src/wine.mk
@@ -1,0 +1,18 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+
+PKG             := wine
+$(PKG)_WEBSITE  := https://www.winehq.org/
+$(PKG)_DESCR    := Wine Is Not an Emulator
+$(PKG)_IGNORE   :=
+$(PKG)_VERSION  := 8.0
+$(PKG)_CHECKSUM := 0272c20938f8721ae4510afaa8b36037457dd57661e4d664231079b9e91c792e
+$(PKG)_SUBDIR   := $(PKG)-$($(PKG)_VERSION)
+$(PKG)_FILE     := $($(PKG)_SUBDIR).tar.xz
+$(PKG)_URL      := https://dl.winehq.org/$(PKG)/source/$($(PKG)_VERSION)/$($(PKG)_FILE)
+$(PKG)_DEPS     :=
+$(PKG)_TARGETS  := $(BUILD)
+$(PKG)_TYPE     := source-only
+
+$(PKG)_DESTDIR  := $(PREFIX)/$(PKG)
+$(PKG)_TOOLDIR  := $($(PKG)_DESTDIR)/bin
+$(PKG)_NLS_DIR  := $($(PKG)_DESTDIR)/share/wine/nls


### PR DESCRIPTION
* packaging into *.zip + *.tar.gz as the build goes
* Wine build tools integration (to complement llvm-windres)
* libdwarf + drmingw for on-device postmortem debugging

- addresses various action points in https://github.com/armdevvel/mxe-SHARED/issues/19
- Wine build tools are prerequisites for `nssm` (background service management)