### PR TITLE
osslsigncode/popen2: Satisfy requirement of -fPIE on popen2 build

### DIFF
--- a/src/popen2.mk
+++ b/src/popen2.mk
@@ -11,7 +11,7 @@ $(PKG)_DEPS     := cc
 $(PKG)_TARGETS  := $(BUILD)
 
 define $(PKG)_BUILD
-    $(if $(BUILD_CROSS),'$(TARGET)-',)gcc -c '$(SOURCE_DIR)/popen2.c' -o '$(BUILD_DIR)/popen2.o' \
+    $(if $(BUILD_CROSS),'$(TARGET)-',)gcc $(if $(BUILD_CROSS),'','-fPIE') -c '$(SOURCE_DIR)/popen2.c' -o '$(BUILD_DIR)/popen2.o' \
         && '$(INSTALL)' -m 644 '$(BUILD_DIR)/popen2.o' '$(PREFIX)/$(TARGET)/lib' \
         && '$(INSTALL)' -m 644 '$(SOURCE_DIR)/popen2.h' '$(PREFIX)/$(TARGET)/include' \
         && $(INSTALL) -d '$(PREFIX)/$(TARGET)/lib/pkgconfig' \


### PR DESCRIPTION
For some reason, osslsigncode doesn't want to build if popen2 is not built with `-fPIE`. Adding it simply fixes it.

[Error log for osslsigncode](https://gist.github.com/pahaze/64b76a63bfaabb16bf1f2a9a0602f6c0) if curious, though.