### PR TITLE
A simple "continuous integration" script

### DIFF
--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -13,10 +13,11 @@ if [ -d usr/$DEPLOY_TRG ]; then
     if make $DEPLOY_PKG; then
       if [ -n $DEPLOY_NET ]; then
         DEPLOY_ZIP=${DEPLOY_PKG}_${DEPLOY_TRG}.zip
-        echo; echo "Deploying $DEPLOY_ZIP to $DEPLOY_NET:"
+        echo; echo "Deploying $DEPLOY_ZIP to $DEPLOY_NET:$DEPLOY_DIR"
         if scp out/${DEPLOY_TRG}/zip/latest/${DEPLOY_ZIP} $DEPLOY_NET:$DEPLOY_DIR
         then
-          ssh $DEPLOY_NET -C "unzip -o $DEPLOY_ZIP"
+          echo "Unpacking: cd $DEPLOY_DIR && unzip -o $DEPLOY_ZIP"
+          ssh $DEPLOY_NET -C "cd $DEPLOY_DIR && unzip -o $DEPLOY_ZIP"
           if [ -n $DEPLOY_EXE ]; then
             echo; echo "Running $DEPLOY_EXE on $DEPLOY_NET (assuming correct PATH):"
             ssh $DEPLOY_NET -C "$DEPLOY_EXE"

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+DEPLOY_TRG=${DEPLOY_TRG:-armv7-w64-mingw32}
+if [ -d usr/$DEPLOY_TRG ]; then
+  echo "Found target: $DEPLOY_TRG"
+  DEPLOY_LST=`ls -t out/$DEPLOY_TRG/zip/latest/ | head -n 1 | cut -f 1 -d _`
+  DEPLOY_PKG=${DEPLOY_PKG:-$DEPLOY_LST}
+  DEPLOY_MKF=src/$DEPLOY_PKG.mk
+  if [ -f $DEPLOY_MKF ]; then
+    echo "Found package: $DEPLOY_PKG"
+    DEPLOY_EXE=${DEPLOY_EXE:-test-$DEPLOY_PKG.exe}
+    touch $DEPLOY_MKF
+    if make $DEPLOY_PKG; then
+      if [ -n $DEPLOY_NET ]; then
+        DEPLOY_ZIP=${DEPLOY_PKG}_${DEPLOY_TRG}.zip
+        echo; echo "Deploying $DEPLOY_ZIP to $DEPLOY_NET:"
+        if scp out/${DEPLOY_TRG}/zip/latest/${DEPLOY_ZIP} $DEPLOY_NET:$DEPLOY_DIR
+        then
+          ssh $DEPLOY_NET -C "unzip -o $DEPLOY_ZIP"
+          if [ -n $DEPLOY_EXE ]; then
+            echo; echo "Running $DEPLOY_EXE on $DEPLOY_NET (assuming correct PATH):"
+            ssh $DEPLOY_NET -C "$DEPLOY_EXE"
+          fi
+        fi
+      fi
+    fi
+    else echo "No such package: $DEPLOY_PKG"
+  fi
+else echo "No such target: $DEPLOY_TRG"
+fi


### PR DESCRIPTION
## Configuration

```
$ tail ~/.bashrc

export DEPLOY_DIR=/Rita/
export DEPLOY_NET=me@dina-talaat
#export DEPLOY_PKG=memmap # inferred (latest built), uncomment to override
#export DEPLOY_TRG=armv7-w64-mingw32 # default, uncomment to override
```

## Usage

Assuming the currently worked-on package is `libmemmap` (its ZIP archive is the latest-updated symlink in `*/latest`):
```
$ export DEPLOY_EXE=test-memmap.exe
```
If `DEPLOY_EXE` is undefined, the script assumes `test-${DEPLOY_PKG}.exe` to be the test binary name.
In the current package there are multiple test/sample/demo executables and we have to choose explicitly.

```
$ tools/ci.sh
Found target: armv7-w64-mingw32
Found package: libmemmap
[local]       libmemmap              /home/lxe/Code/libmemmap
[build]       libmemmap              armv7-w64-mingw32
[done]        libmemmap              armv7-w64-mingw32
                  552 KiB        0m12.034s

Deploying libmemmap_armv7-w64-mingw32.zip to me@dina-talaat:
libmemmap_armv7-w64-mingw32.zip               100%   91KB 441.5KB/s   00:00
Archive:  libmemmap_armv7-w64-mingw32.zip
 extracting: installed/libmemmap
  inflating: lib/libmemmap.dll.a
  inflating: bin/test-memmap.exe
  inflating: bin/libmemmap.dll
  inflating: bin/test-memdmp.exe

Running test-memmap.exe on me@dina-talaat (assuming correct PATH):
sys/mman.h API test panel.

mincore() test completed.
VirtualAlloc(00000000, 1000, 3000, 4)
mmap(anon) errno=0
```

## Notes
`touch` is needed to re-trigger a local build.