### PR TITLE
Component/toybox

### DIFF
--- a/src/getline-compatible.mk
+++ b/src/getline-compatible.mk
@@ -1,0 +1,16 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+
+PKG             := getline-compatible
+$(PKG)_WEBSITE  := https://github.com/treeswift/$(PKG)
+$(PKG)_IGNORE   :=
+$(PKG)_VERSION  := 1.0.0
+$(PKG)_CHECKSUM := 817e6081bac2c45fc27a0114f6803227b3cde7fa164eb33278493ecebffed50d
+$(PKG)_GH_CONF  := treeswift/$(PKG)/tags,
+$(PKG)_DEPS     := cc
+
+define $(PKG)_BUILD
+    '$(MXE_MESON_WRAPPER)' $(MXE_MESON_OPTS) \
+        '$(BUILD_DIR)' '$(SOURCE_DIR)'
+    '$(MXE_NINJA)' -C '$(BUILD_DIR)' -j '$(JOBS)'
+    '$(MXE_NINJA)' -C '$(BUILD_DIR)' -j 1 install
+endef

--- a/src/glob.mk
+++ b/src/glob.mk
@@ -2,15 +2,18 @@ PKG             := glob
 $(PKG)_WEBSITE  := https://man.openbsd.org/glob.3
 $(PKG)_DESCR    := globbing (wildcard file search and iteration) -- BSD license
 $(PKG)_IGNORE   :=
-$(PKG)_VERSION  := 1.0.2
-$(PKG)_CHECKSUM := 164b86fc3ba1cd08d8162b8ace15154f9388583aae3d52d2bd5e78134607ed51
+$(PKG)_VERSION  := 1.0.3
+$(PKG)_CHECKSUM := 29fdba6af79ffd0fbebe541ea2c96a4fe71e4777023212f1ce2b241b330f0cf7
 $(PKG)_SUBDIR   := $(PKG)-$($(PKG)_VERSION)
 $(PKG)_FILE     := $(PKG)-$($(PKG)_VERSION).tar.gz
 $(PKG)_URL      := https://github.com/treeswift/$(PKG)/archive/refs/tags/$($(PKG)_VERSION).tar.gz
 $(PKG)_DEPS     := cc libwusers
 
+# Provides:
+# - glob()
+# - fnmatch()
+
 # Notes:
-# - user list expansion is not (sup)ported as of 1.0.1 - once ported, define HAS_PWD_H;
 # - lstat() is hardwired to be stat() since Windows RT does not support symbolic links;
 # - in the only occurrence of strlcpy() - copy to buf[] - strncpy() can be used instead
 
@@ -19,20 +22,9 @@ $(PKG)_DEPS     := cc libwusers
 # - package metadata (*.pc)
 
 define $(PKG)_BUILD
-    $(TARGET)-gcc '$(SOURCE_DIR)/glob.c' -c \
-        -isystem '$(SOURCE_DIR)' \
-        '-Du_char=unsigned char' \
-        '-Du_short=unsigned short' \
-        '-Du_int=unsigned int' \
-        '-Dlstat=stat' \
-        '-DS_ISLNK(m)=0' \
-        '-DHAS_PWD_H' \
-        '-Dstrlcpy=strncpy' \
-        -o '$(BUILD_DIR)/glob.o'
-    $(INSTALL) -m 644 '$(SOURCE_DIR)/charclass.h' \
-        '$(PREFIX)/$(TARGET)/include/'
-    $(INSTALL) -m 644 '$(SOURCE_DIR)/glob.h' \
-        '$(PREFIX)/$(TARGET)/include/'
-    $(INSTALL) -m 644 '$(BUILD_DIR)/glob.o' \
-        '$(PREFIX)/$(TARGET)/lib/'
+    '$(MXE_MESON_WRAPPER)' $(MXE_MESON_OPTS) \
+         -Dc_link_args='-Wl,-lwusers' \
+        '$(BUILD_DIR)' '$(SOURCE_DIR)'
+    '$(MXE_NINJA)' -C '$(BUILD_DIR)' -j '$(JOBS)'
+    '$(MXE_NINJA)' -C '$(BUILD_DIR)' -j 1 install
 endef

--- a/src/libfatctl.mk
+++ b/src/libfatctl.mk
@@ -1,0 +1,18 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+
+PKG             := libfatctl
+$(PKG)_DESCR    := *nix fd API on Windows
+$(PKG)_WEBSITE  := https://github.com/treeswift/$(PKG)
+$(PKG)_IGNORE   :=
+$(PKG)_VERSION  := 0.3.0
+$(PKG)_CHECKSUM := c03b74afa699202b5dc487672b01fa2f71c7ff7fcc407d369265f8fd615ac7e0
+$(PKG)_GH_CONF  := treeswift/$(PKG)/tags,
+$(PKG)_DEPS     := cc
+
+define $(PKG)_BUILD
+    '$(MXE_MESON_WRAPPER)' $(MXE_MESON_OPTS) \
+        -Dfilesystem=std::__fs::filesystem \
+        '$(BUILD_DIR)' '$(SOURCE_DIR)'
+    '$(MXE_NINJA)' -C '$(BUILD_DIR)' -j '$(JOBS)'
+    '$(MXE_NINJA)' -C '$(BUILD_DIR)' -j 1 install
+endef

--- a/src/libmemmap.mk
+++ b/src/libmemmap.mk
@@ -1,0 +1,17 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+
+PKG             := libmemmap
+$(PKG)_DESCR    := *nix VM API on Windows
+$(PKG)_WEBSITE  := https://github.com/treeswift/$(PKG)
+$(PKG)_IGNORE   :=
+$(PKG)_VERSION  := 0.0.2
+$(PKG)_CHECKSUM := 562e90fb0ca96a790794cfb06759a07e299db8df1d7826e1554fd6283aa4f263
+$(PKG)_GH_CONF  := treeswift/$(PKG)/tags,
+$(PKG)_DEPS     := cc libfatctl
+
+define $(PKG)_BUILD
+    '$(MXE_MESON_WRAPPER)' $(MXE_MESON_OPTS) \
+        '$(BUILD_DIR)' '$(SOURCE_DIR)'
+    '$(MXE_NINJA)' -C '$(BUILD_DIR)' -j '$(JOBS)'
+    '$(MXE_NINJA)' -C '$(BUILD_DIR)' -j 1 install
+endef

--- a/src/libob.mk
+++ b/src/libob.mk
@@ -1,0 +1,16 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+
+PKG             := libob
+$(PKG)_WEBSITE  := https://github.com/OlafSimon/strptime-for-Windows-Linux
+$(PKG)_IGNORE   :=
+$(PKG)_VERSION  := 1.0.0
+$(PKG)_CHECKSUM := b2f84cc2bce4125eec2123f16e9502d67fb54ea713d10435c1a0b33accac4b5c
+$(PKG)_GH_CONF  := treeswift/strptime/tags,
+$(PKG)_DEPS     := cc
+
+define $(PKG)_BUILD
+    '$(MXE_MESON_WRAPPER)' $(MXE_MESON_OPTS) \
+        '$(BUILD_DIR)' '$(SOURCE_DIR)'
+    '$(MXE_NINJA)' -C '$(BUILD_DIR)' -j '$(JOBS)'
+    '$(MXE_NINJA)' -C '$(BUILD_DIR)' -j 1 install
+endef

--- a/src/libprefix.mk
+++ b/src/libprefix.mk
@@ -1,0 +1,17 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+
+PKG             := libprefix
+$(PKG)_DESCR    := known path lookup library <paths.h>
+$(PKG)_WEBSITE  := https://github.com/armdevvel/prefix
+$(PKG)_IGNORE   :=
+$(PKG)_VERSION  := 0.0.1
+$(PKG)_CHECKSUM := e2abd0adc625ddd543f2c54a1ce723d5a574ac4228db846007eb061681f54ed5
+$(PKG)_GH_CONF  := armdevvel/prefix/tags,
+$(PKG)_DEPS     := cc
+
+define $(PKG)_BUILD
+    '$(MXE_MESON_WRAPPER)' $(MXE_MESON_OPTS) \
+        '$(BUILD_DIR)' '$(SOURCE_DIR)'
+    '$(MXE_NINJA)' -C '$(BUILD_DIR)' -j '$(JOBS)'
+    '$(MXE_NINJA)' -C '$(BUILD_DIR)' -j 1 install
+endef

--- a/src/libwusers.mk
+++ b/src/libwusers.mk
@@ -3,9 +3,9 @@
 PKG             := libwusers
 $(PKG)_WEBSITE  := https://github.com/treeswift/libwusers
 $(PKG)_IGNORE   :=
-$(PKG)_VERSION  := 0.0.4
-$(PKG)_CHECKSUM := 7b74e98856f76ea5f9505f05cc540aa286c25bf98e3967d5c77140d412def013
-$(PKG)_GH_CONF  := treeswift/libwusers/tags/tag,,,
+$(PKG)_VERSION  := 0.0.5
+$(PKG)_CHECKSUM := 96b24e7d9a1d11dfc002418b924454cf08dc4e7172f9959f0975532b03895cdc
+$(PKG)_GH_CONF  := treeswift/libwusers/tags,
 $(PKG)_DEPS     := cc
 
 define $(PKG)_BUILD

--- a/src/tar.mk
+++ b/src/tar.mk
@@ -41,7 +41,7 @@ define $(PKG)_BUILD
         $(MXE_CONFIGURE_OPTS) \
         "CFLAGS=-DMSDOS=1" \
     && $(MAKE) \
-        LDFLAGS='$(PREFIX)/$(TARGET)/lib/glob.o -lwusers -lbcrypt -lws2_32 -lssp' \
+        LDFLAGS='-lglob -lwusers -lbcrypt -lws2_32 -lssp' \
         -j '$(JOBS)' \
         install
 endef

--- a/src/toybox.mk
+++ b/src/toybox.mk
@@ -1,0 +1,28 @@
+# This file is part of MXE. See LICENSE.md for licensing information.
+
+PKG             := toybox
+$(PKG)_WEBSITE  := https://landley.net/toybox/
+$(PKG)_DESCR    := Toybox: all-in-one Linux command line. Public domain.
+$(PKG)_IGNORE   :=
+$(PKG)_VERSION  := 0.8.10-mingw-0.0.1
+$(PKG)_CHECKSUM := 447331a3530ababbaabba16d0e680aa0cf09f8841c347fb02050f1fef015e87f
+$(PKG)_GH_CONF  := treeswift/toybox-mingw/tags
+# TODO: (some part of) the hellish list of dependencies below will be moved to the 'libmoregw' meta-package
+$(PKG)_DEPS     := cc libwusers libfatctl libmemmap ws2fwd pcre2 glob getline-compatible libob openssl zlib
+
+$(PKG)_OUTNAME = $(PKG).exe
+$(PKG)_OUTFILE = $($(PKG)_OUTNAME)
+$(PKG)_DBGFILE = generated/unstripped/$($(PKG)_OUTNAME)
+
+$(PKG)_MAKE = $(MAKE) -j '$(JOBS)' \
+        CROSS_COMPILE='$(TARGET)-' \
+        OUTNAME=$($(PKG)_OUTNAME)
+
+# TODO: replace _DBGFILE with _OUTFILE in OUTFILE when we are relatively stable
+define $(PKG)_BUILD
+    cd '$(SOURCE_DIR)' \
+    && cp win32-config .config \
+    && $($(PKG)_MAKE) oldconfig --keep-going \
+    && $($(PKG)_MAKE) --keep-going \
+    && env 'OUTFILE=$($(PKG)_DBGFILE)' env 'DBGFILE=$($(PKG)_DBGFILE)' env 'PREFIX=$(PREFIX)' env 'TARGET=$(TARGET)' scripts/winstall.sh
+endef

--- a/src/toybox.mk
+++ b/src/toybox.mk
@@ -4,11 +4,11 @@ PKG             := toybox
 $(PKG)_WEBSITE  := https://landley.net/toybox/
 $(PKG)_DESCR    := Toybox: all-in-one Linux command line. Public domain.
 $(PKG)_IGNORE   :=
-$(PKG)_VERSION  := 0.8.10-mingw-0.0.1
-$(PKG)_CHECKSUM := 447331a3530ababbaabba16d0e680aa0cf09f8841c347fb02050f1fef015e87f
+$(PKG)_VERSION  := 0.8.10-mingw-0.0.2
+$(PKG)_CHECKSUM := 3bc4f6e020214b2655d1df43f27504e13c9dc6de84e283c4d2c95008e5fda4ab
 $(PKG)_GH_CONF  := treeswift/toybox-mingw/tags
 # TODO: (some part of) the hellish list of dependencies below will be moved to the 'libmoregw' meta-package
-$(PKG)_DEPS     := cc libwusers libfatctl libmemmap ws2fwd pcre2 glob getline-compatible libob openssl zlib
+$(PKG)_DEPS     := cc libwusers libfatctl libmemmap ws2fwd pcre2 glob getline-compatible libob libprefix openssl zlib
 
 $(PKG)_OUTNAME = $(PKG).exe
 $(PKG)_OUTFILE = $($(PKG)_OUTNAME)

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -1,26 +1,76 @@
 #!/bin/sh
 
-DEPLOY_TRG=${DEPLOY_TRG:-armv7-w64-mingw32}
+TOUCH=touch
+
+while :; do
+  case "$1" in
+    -h) cat << 'EOHELP'
+
+    tools/ci.sh is a simple script for package build/test automation.
+
+    Parameters are accepted in the form of environment variables:
+
+    DEPLOY_TRG  target architecture     (default: 'armv7-w64-mingw32')
+    DEPLOY_PKG  package to test         (default: last built)
+    DEPLOY_NET  [user@]host to scp to   (no default)
+    DEPLOY_DIR  installation directory, e.g. emulated sysroot (no default)
+    DEPLOY_EXE  test case command line  (default: 'test-<DEPLOY_PKG>.exe')
+    DEPLOY_DBG  instrumentation program (no default)
+
+    You may want to set DEPLOY_NET and DEPLOY_DIR in your '.bashrc' file.
+
+    The following command line switches are accepted:
+      -h    display this help page and exit
+      -k    do not force rebuild
+      -c    use `catchsegv` as DEPLOY_DBG (assuming DrMingw is installed)
+
+    Prerequisites:
+      (1) sshd (package 'openssh-portable') must be running on the target;
+      (2) unzip must be installed on the target and present in the $PATH.
+
+EOHELP
+      exit 0
+      ;;
+    -k) TOUCH=true
+      ;;
+    -c) DEPLOY_DBG="catchsegv"
+      ;;
+    *) break
+  esac
+
+  shift
+done
+
+DEPLOY_TRG="${DEPLOY_TRG:-armv7-w64-mingw32}"
+
 if [ -d usr/$DEPLOY_TRG ]; then
   echo "Found target: $DEPLOY_TRG"
   DEPLOY_LST=`ls -t out/$DEPLOY_TRG/zip/latest/ | head -n 1 | cut -f 1 -d _`
-  DEPLOY_PKG=${DEPLOY_PKG:-$DEPLOY_LST}
-  DEPLOY_MKF=src/$DEPLOY_PKG.mk
-  if [ -f $DEPLOY_MKF ]; then
+  DEPLOY_PKG="${DEPLOY_PKG:-$DEPLOY_LST}"
+  DEPLOY_MKF="src/$DEPLOY_PKG.mk"
+  if [ -f "$DEPLOY_MKF" ]; then
     echo "Found package: $DEPLOY_PKG"
     DEPLOY_EXE=${DEPLOY_EXE:-test-$DEPLOY_PKG.exe}
-    touch $DEPLOY_MKF
-    if make $DEPLOY_PKG; then
-      if [ -n $DEPLOY_NET ]; then
-        DEPLOY_ZIP=${DEPLOY_PKG}_${DEPLOY_TRG}.zip
+    if [ -n "$DEPLOY_DBG" ]; then
+      echo "Run test with: ${DEPLOY_DBG}"
+      DEPLOY_EXE="${DEPLOY_DBG} ${DEPLOY_EXE}"
+    fi
+    if [ 'true' = "$TOUCH" ] && grep -H -v '^#' "$DEPLOY_MKF" | grep _SOURCE_TREE; then
+      echo "Note: make can't detect changes in local sources. Consider running w/o -k."
+      echo
+    fi
+    $TOUCH "$DEPLOY_MKF"
+    if make "$DEPLOY_PKG"; then
+      if [ -n "$DEPLOY_NET" ]; then
+        DEPLOY_ZIP="${DEPLOY_PKG}_${DEPLOY_TRG}.zip"
         echo; echo "Deploying $DEPLOY_ZIP to $DEPLOY_NET:$DEPLOY_DIR"
-        if scp out/${DEPLOY_TRG}/zip/latest/${DEPLOY_ZIP} $DEPLOY_NET:$DEPLOY_DIR
+        if scp "out/${DEPLOY_TRG}/zip/latest/${DEPLOY_ZIP}" "$DEPLOY_NET:$DEPLOY_DIR"
         then
           echo "Unpacking: cd $DEPLOY_DIR && unzip -o $DEPLOY_ZIP"
-          ssh $DEPLOY_NET -C "cd $DEPLOY_DIR && unzip -o $DEPLOY_ZIP"
+          ssh "$DEPLOY_NET" -C "cd $DEPLOY_DIR && unzip -o $DEPLOY_ZIP"
           if [ -n "$DEPLOY_EXE" ]; then
             echo; echo "Running $DEPLOY_EXE on $DEPLOY_NET (assuming correct PATH):"
-            ssh $DEPLOY_NET -C "$DEPLOY_EXE"
+            ssh "$DEPLOY_NET" -C "$DEPLOY_EXE"
           fi
         fi
       fi


### PR DESCRIPTION
This pull request integrates `toybox`, a collection of *nix tools within a single multi-use binary.
It is also a showcase of:
* https://github.com/treeswift/libfatctl (extra *nix fd APIs on MinGW);
* https://github.com/treeswift/libmemmap (a Windows implementation of `sys/mman.h`).

The Windows/MinGW fork of `toybox` being used provides approximately a third of the tools claimed by mainline [Toybox](https://landley.net/toybox), and roughly a half of the ones currently selected in its configuration. The ones that fail to build (approximately 90) are removed from the build. The ones that make it (also around 90) may not work as intended due to extensive stubbing of POSIX and Linux API, the lack of `/sys` and `/proc`, differences between *nix and Windows permission models, differences between *nix and Windows pipes and, finally, the proverbial lack of `fork`. However, this is still a significant expansion of our command line utility zoo.

Overall and optimistically, this garage sale buys us the following list of tools (some commands that make no sense on Windows are yet to be removed, but I am too happy right now with having prettified the build as is):

```
+[ +acpi -arch +ascii +base32 +base64 +basename -bash -blkdiscard
-blkid +bunzip2 +bzcat +cal +cat -chattr -chgrp +chmod -chown +chroot
-chvt +cksum +clear +cmp +comm -count -cp -cpio +crc32 +cut -date
-dd -deallocvt -devmem -df +dirname +dos2unix -du +echo +egrep -eject
+env +expand +factor +false +fgrep +file -find +fmt -free -freeramdisk
-fsfreeze -fstype -fsync +ftpget +ftpput +getopt -gitcheckout -gitclone
-gitfetch -gitinit -gitremote -gpiodetect -gpiofind -gpioget -gpioinfo
-gpioset +grep -groups +gunzip +gzip +head +help -hexedit +httpd -iconv
-id -inotifyd -install -iotop -kill -killall5 +link -linux32 +ln +logger
-logname -ls -lsattr +lsmod +lspci +lsusb -makedevs +mcookie +md5sum
+mkdir -mkfifo -mkpasswd +mountpoint -mv -nbd-client -nbd-server -nice
+nl +nohup -nproc +od -partprobe +paste +patch -pgrep +pidof -pivot_root
-pkill +pmap +printenv +printf -prlimit -ps +pwd +pwdx +pwgen -readahead
+readelf +readlink +realpath +renice +reset +rev +rm +rmdir -rtcwake
+sed +seq -setfattr -sh +sha1sum +sha224sum +sha256sum +sha384sum
+sha3sum +sha512sum +shred -shuf +sleep +sort +split -stat +strings
+sysctl +tac +tail -tar -taskset +tee +test -time -timeout -top -touch
-toysh +tr +true +truncate -tty -uclampset -ulimit -uname +unicode
+uniq +unix2dos +unlink -unshare -uptime +usleep +uudecode +uuencode
+uuidgen -vconfig -vmstat -w -watch -watchdog +wc -wget +which -who
-whoami -xargs +xxd +yes +zcat
```

`cat` works, `grep` works; some missing utilities, such as `wget`, only have a few holes to plumb.
Command files (`*.cmd`) will be replaced with hardlinks once we have installation hooks in place.

File issues at: https://github.com/treeswift/toybox-mingw/issues