### PR TITLE
Fix libmysqlclient on newer GCC versions

### DIFF
--- a/src/libmysqlclient-2-fix-header-order.patch
+++ b/src/libmysqlclient-2-fix-header-order.patch
@@ -1,0 +1,34 @@
+diff '--color=auto' -Naur a/extra/yassl/src/ssl.cpp b/extra/yassl/src/ssl.cpp
+--- a/extra/yassl/src/ssl.cpp	2025-06-29 03:46:53.570355916 -0400
++++ b/extra/yassl/src/ssl.cpp	2025-06-29 03:47:30.803161329 -0400
+@@ -28,6 +28,14 @@
+ 
+ /*  see man pages for function descriptions */
+ 
++#ifdef _WIN32
++    #include <windows.h>    // FindFirstFile etc..
++#else
++    #include <sys/types.h>  // file helper
++    #include <sys/stat.h>   // stat
++    #include <dirent.h>     // opendir
++#endif
++
+ #include "runtime.hpp"
+ #include "openssl/ssl.h"
+ #include "handshake.hpp"
+@@ -39,15 +47,6 @@
+ #include "helpers.hpp"          // for placement new hack
+ #include <stdio.h>
+ 
+-#ifdef _WIN32
+-    #include <windows.h>    // FindFirstFile etc..
+-#else
+-    #include <sys/types.h>  // file helper
+-    #include <sys/stat.h>   // stat
+-    #include <dirent.h>     // opendir
+-#endif
+-
+-
+ namespace yaSSL {
+ 
+ 

--- a/src/libmysqlclient-3-fix-sig_return-typedef.patch
+++ b/src/libmysqlclient-3-fix-sig_return-typedef.patch
@@ -1,0 +1,12 @@
+diff '--color=auto' -Naur a/include/my_global.h b/include/my_global.h
+--- a/include/my_global.h	2025-06-29 03:54:10.376675189 -0400
++++ b/include/my_global.h	2025-06-29 03:54:05.662657330 -0400
+@@ -192,7 +192,7 @@
+ #define INVALID_SOCKET -1
+ #endif
+ C_MODE_START
+-typedef void	(*sig_return)();/* Returns type from signal */
++typedef void	(*sig_return)(int);/* Returns type from signal */
+ C_MODE_END
+ #if defined(__GNUC__)
+ typedef char	pchar;		/* Mixed prototypes can take char */


### PR DESCRIPTION
Apparently, newer versions of GCC are very unhappy with libmysqlclient's source code due to wrong header inclusion order, and also an incorrectly defined typedef. I have tested these patches on Fedora 42 (using GCC `15.1.1 20250521 (Red Hat 15.1.1-2)`), as well as on Ubuntu 24.04 (using GCC `(Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0)`), and they both successfully compile. Regardless, as usual, I would like your alls' testing and opinion.